### PR TITLE
Add Ubuntu style and example desktop Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Modern browsers do not provide APIs to directly use TCP or UDP. WebVM provides n
 
 You can now customize `dockerfiles/debian_mini` to suit your needs, or make a new Dockerfile from scratch. Use the `Path to Dockerfile` workflow parameter to select it.
 
+For a more complete graphical setup, try the example `dockerfiles/ubuntu_desktop` Dockerfile. It adds an Ubuntu-style XFCE environment with Firefox and Sublime Text.
+
 # Run WebVM locally with a custom Debian mini disk image
 
 1. Clone the WebVM Repository
@@ -142,6 +144,10 @@ index 2878332..1f3103a 100644
 -CMD [ "/bin/bash" ]
 +CMD [ "/usr/bin/python3" ]
 ```
+
+## Example customization: Ubuntu-like desktop
+
+An additional Dockerfile, `dockerfiles/ubuntu_desktop`, installs an XFCE desktop along with Firefox and Sublime Text. Build an image from it to get a WebVM that looks and behaves much like Ubuntu.
 
 # How to use Claude AI
 

--- a/dockerfiles/ubuntu_desktop
+++ b/dockerfiles/ubuntu_desktop
@@ -1,0 +1,15 @@
+FROM --platform=i386 i386/ubuntu:focal
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get install -y \
+        xorg xfce4 firefox \
+        wget curl git vim \
+        apt-transport-https ca-certificates gnupg && \
+    wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | apt-key add - && \
+    echo "deb https://download.sublimetext.com/ apt/stable/" > /etc/apt/sources.list.d/sublime-text.list && \
+    apt-get update && apt-get install -y sublime-text && \
+    useradd -m user && echo "user:password" | chpasswd && \
+    echo 'root:password' | chpasswd
+
+CMD ["/usr/bin/startxfce4"]

--- a/src/lib/Icon.svelte
+++ b/src/lib/Icon.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div 
-	class="p-3 cursor-pointer text-center hover:bg-neutral-600 {$activity ? "text-amber-500 animate-pulse" : "hover:text-gray-100"}"
+	class="p-3 cursor-pointer text-center hover:bg-[#772953] {$activity ? "text-orange-500 animate-pulse" : "hover:text-gray-100"}"
 	style="animation-duration: 0.5s"
 	on:mouseenter={handleMouseover}
 	on:click={handleClick}

--- a/src/lib/SideBar.svelte
+++ b/src/lib/SideBar.svelte
@@ -67,7 +67,7 @@
 	export let handleTool;
 </script>
 
-<div class="flex flex-row w-14 h-full bg-neutral-700" >
+<div class="flex flex-row w-14 h-full bg-[#2c001e]" >
 	<div class="flex flex-col shrink-0 w-14 text-gray-300">
 		{#each icons as i}
 			{#if i}
@@ -94,7 +94,7 @@
 				buttonIcon="fa-solid fa-thumbtack"
 				clickHandler={toggleSidebarPin}
 				buttonTooltip={sideBarPinned ? "Unpin Sidebar" : "Pin Sidebar"}
-				bgColor={sideBarPinned ? "bg-neutral-500" : "bg-neutral-700"}
+                               bgColor={sideBarPinned ? "bg-neutral-500" : "bg-[#2c001e]"}
 			/>
 		</div>
 		{#if activeInfo === 'Information'}

--- a/src/lib/global.css
+++ b/src/lib/global.css
@@ -1,15 +1,16 @@
-@import url('https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap');
 
 @tailwind base;
 @tailwind utilities;
 
 body
 {
-	font-family: Archivo, sans-serif;
-	margin: 0;
-	height: 100%;
-	overflow: hidden;
-	background: black;
+        font-family: Ubuntu, sans-serif;
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #2c001e;
+        color: #eee;
 }
 
 html


### PR DESCRIPTION
## Summary
- integrate an Ubuntu-like theme using the Ubuntu font and colors
- adjust sidebar and icons to match the new style
- document how to build an Ubuntu-style desktop with Firefox and Sublime Text
- provide a sample Dockerfile for this Ubuntu XFCE environment

## Testing
- `npm install`
- `npm run build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686bfce14c908331a4400f0d4ab92aa4